### PR TITLE
Adjust summary heading for early Cyprus time

### DIFF
--- a/src/summarize.py
+++ b/src/summarize.py
@@ -7,6 +7,7 @@ import sys
 import argparse
 import json
 from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
 from helpers import get_text_folder_for_day
 from openai import OpenAI
 from dateutil.parser import parse as parse_datetime, ParserError
@@ -292,7 +293,9 @@ def summarize_for_day(day):
     output_folder = get_text_folder_for_day(day)
 
     date_heading = f"## 📰 News Summary for {day.strftime('%A, %d %B %Y')}\n\n"
-    date_heading += "This is a summary of yesterday's [8pm RIK news broadcast](https://tv.rik.cy/show/eideseis-ton-8/). Where available, links to related English-language articles from the Cyprus Mail and In-Cyprus are provided for further reading. Please note that this summary was generated with the assistance of AI and may contain inaccuracies."
+    cyprus_now = datetime.now(ZoneInfo("Asia/Nicosia"))
+    summary_reference = "this evening's" if cyprus_now.hour < 2 else "yesterday's"
+    date_heading += f"This is a summary of {summary_reference} [8pm RIK news broadcast](https://tv.rik.cy/show/eideseis-ton-8/). Where available, links to related English-language articles from the Cyprus Mail and In-Cyprus are provided for further reading. Please note that this summary was generated with the assistance of AI and may contain inaccuracies."
 
     summary_file = output_folder / "summary_without_links.txt"
     output_file = output_folder / "summary.txt"


### PR DESCRIPTION
### Motivation
- Ensure the summary heading references "this evening's" when the summary is generated before 2am Cyprus time so the broadcast reference is accurate.
- Avoid confusing readers with "yesterday's" wording during early-morning runs in the Cyprus timezone.

### Description
- Import `ZoneInfo` and compute `cyprus_now = datetime.now(ZoneInfo("Asia/Nicosia"))` in `summarize_for_day`.
- Determine `summary_reference` as `"this evening's"` when `cyprus_now.hour < 2` else `"yesterday's"`.
- Update the `date_heading` construction in `src/summarize.py` to interpolate the `summary_reference` into the heading text.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957dfd2d68883318767ce2695251bcc)