### PR TITLE
Add basic unit tests for helpers, image, and summarize

### DIFF
--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,40 @@
+import importlib
+import os
+from datetime import date
+from pathlib import Path
+import tempfile
+import sys
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT / "src"))
+
+
+class HelpersTestCase(unittest.TestCase):
+    def test_make_folders_creates_expected_dirs(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.environ["SUMMARIES_ROOT"] = tmpdir
+            helpers = importlib.import_module("helpers")
+            helpers = importlib.reload(helpers)
+
+            target_day = date(2024, 1, 15)
+            helpers.make_folders(target_day)
+
+            root = Path(tmpdir) / "2024-01-15"
+            self.assertTrue(root.exists())
+            self.assertTrue((root / "media").exists())
+            self.assertTrue((root / "txt").exists())
+
+    def test_get_root_folder_for_day_uses_env_root(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.environ["SUMMARIES_ROOT"] = tmpdir
+            helpers = importlib.import_module("helpers")
+            helpers = importlib.reload(helpers)
+
+            target_day = date(2024, 5, 20)
+            expected = Path(tmpdir) / "2024-05-20"
+            self.assertEqual(helpers.get_root_folder_for_day(target_day), expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1,0 +1,34 @@
+import sys
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT / "src"))
+
+import image
+
+
+class ImageTestCase(unittest.TestCase):
+    def test_extract_top_stories_from_markdown_bullets(self):
+        markdown = """# Daily Brief\n\n- Story one\n- Story two\n\nMore text here."""
+        extracted = image.extract_top_stories_from_md(markdown)
+        self.assertEqual(extracted, "- Story one\n- Story two")
+
+    def test_extract_top_stories_from_markdown_fallback(self):
+        markdown = """# Daily Brief\n\nTop stories paragraph.\n\nMore text."""
+        extracted = image.extract_top_stories_from_md(markdown)
+        self.assertEqual(extracted, "Top stories paragraph.")
+
+    def test_build_image_prompt_includes_lead_subject_and_faces_clause(self):
+        prompt = image.build_image_prompt(
+            "Monday, 01 January 2024",
+            "- Budget talks\n- Tourism updates",
+            lead_subject="Budget talks",
+            allow_faces=False,
+        )
+        self.assertIn("Lead subject: Budget talks.", prompt)
+        self.assertIn("Avoid faces", prompt)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_summarize.py
+++ b/tests/test_summarize.py
@@ -1,0 +1,38 @@
+import sys
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT / "src"))
+
+import summarize
+
+
+class SummarizeTestCase(unittest.TestCase):
+    def test_combine_summaries_merges_and_orders_sections(self):
+        chunk_one = """### Top stories\n- Item A\n\n### Culture\n- Item C"""
+        chunk_two = """### Top stories\n- Item B\n\n### Education\n- Item D"""
+
+        combined = summarize.combine_summaries([chunk_one, chunk_two])
+
+        top_index = combined.find("### Top stories")
+        edu_index = combined.find("### Education")
+        culture_index = combined.find("### Culture")
+
+        self.assertNotEqual(top_index, -1)
+        self.assertNotEqual(edu_index, -1)
+        self.assertNotEqual(culture_index, -1)
+        self.assertTrue(top_index < edu_index < culture_index)
+        self.assertIn("- Item A", combined)
+        self.assertIn("- Item B", combined)
+
+    def test_limit_headlines_caps_bullet_count(self):
+        text = """Header\n- One\n- Two\n- Three"""
+        limited = summarize.limit_headlines(text, max_count=2)
+        self.assertIn("- One", limited)
+        self.assertIn("- Two", limited)
+        self.assertNotIn("- Three", limited)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Provide baseline unit test coverage for core utility modules to catch regressions early.
- Verify filesystem helpers that create and resolve summary folders to prevent path errors in production.
- Ensure image prompt extraction and generation helpers produce expected outputs from markdown input.
- Validate summary merging and headline-limiting logic used when combining chunked summaries.

### Description
- Added `tests/test_helpers.py` with tests for `make_folders` and `get_root_folder_for_day` behavior under a temporary `SUMMARIES_ROOT`.
- Added `tests/test_image.py` with tests for `extract_top_stories_from_md` and `build_image_prompt` to confirm markdown parsing and prompt content.
- Added `tests/test_summarize.py` with tests for `combine_summaries` ordering/merging and `limit_headlines` bullet cap behavior.
- Included test scaffolding that adjusts `sys.path` to import the `src` modules and uses `unittest` for execution.

### Testing
- Ran `python -m unittest discover -s tests` which executed the new test suite.
- All tests passed: `7 tests` ran and reported `OK`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957df166ccc8331b63f34b74c0b1d83)