### PR TITLE
Inject president hint whenever ‘president’ is mentioned and expand TRNC context phrases

### DIFF
--- a/src/image.py
+++ b/src/image.py
@@ -92,13 +92,33 @@ def build_image_prompt(day_str: str, headlines_md: str, lead_subject: str | None
     bullets = lines[:4]
     bullets_text = "; ".join(bullets) if bullets else "Cyprus daily news topics"
 
+    def mentions_current_leaders(text: str) -> bool:
+        lowered = text.lower()
+        if any(name in lowered for name in ["christodoulides", "erhürman", "erhurman"]):
+            return True
+        cyprus_context = any(term in lowered for term in ["cyprus", "cypriot", "nicosia"])
+        trnc_context = any(term in lowered for term in [
+            "trnc",
+            "turkish cypriot",
+            "north cyprus",
+            "northern cyprus",
+            "pseudostate",
+            "so-called trnc",
+            "so-called state",
+            "so-called regime",
+            "so-called government",
+        ])
+        has_president = "president" in lowered
+        has_leader = "leader" in lowered
+        return has_president or (has_leader and trnc_context)
+
     face_clause = (
        "If depicting people, use stylized caricature (exaggerated but respectful), avoid likeness-level realism."
         if allow_faces else
         "Avoid faces; use silhouettes, hands, emblems, buildings, or symbolic objects instead. "
     )
 
-    if "president" in bullets_text or "President" in bullets_text:
+    if mentions_current_leaders(bullets_text):
         face_clause = (
         "If depicting people, use stylized caricature (exaggerated but respectful), avoid likeness-level realism. Note that the current president of Cyprus is Nikos Christodoulides; make sure to use his likeness and not that of previous leaders. The current leader of the TRNC is Tufan Erhürman."
             if allow_faces else


### PR DESCRIPTION
### Motivation
- Ensure any headline that mentions a `president` triggers injection of the current-president hint so generated images use the correct incumbent.
- Improve detection of references to the TRNC by recognizing more natural-language phrases to avoid false negatives in leader-hint logic.
- Preserve existing gating for TRNC leader hints by keeping the `leader` + TRNC-context requirement.

### Description
- Updated `src/image.py` and the `mentions_current_leaders` helper used by `build_image_prompt` to always return true when `"president"` appears in the text. 
- Added additional TRNC-related phrases to the `trnc_context` list, including `"pseudostate"`, `"so-called trnc"`, `"so-called state"`, `"so-called regime"`, and `"so-called government"`.
- Simplified the boolean logic to `return has_president or (has_leader and trnc_context)` so any `president` mention triggers the president hint while `leader` still requires TRNC context.
- Kept the existing face guidance content that mentions the current Cyprus president and the TRNC leader intact and gated by `mentions_current_leaders`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957df8894f883318f6de205fbdd8360)