### PR TITLE
use fast type to type faster, hopefully

### DIFF
--- a/src/post_to_substack.py
+++ b/src/post_to_substack.py
@@ -35,10 +35,15 @@ def extract_title_and_body(markdown_text):
     return title, "\n".join(body_lines).strip()
 
 def post_to_substack(md_path, publish=False, cover_path="cover.png"):
+    def fast_type(page, text: str):
+        if not text:
+            return
+        page.keyboard.insert_text(text)
+
     def insert_link(page, label: str, url: str):
         import time
         # Type the label
-        page.keyboard.type(label)
+        fast_type(page, label)
         # Select the label we just typed (character-wise for reliability)
         for _ in range(len(label)):
             page.keyboard.down("Shift")
@@ -47,7 +52,7 @@ def post_to_substack(md_path, publish=False, cover_path="cover.png"):
         # Open link dialog, type URL, confirm
         page.keyboard.down("Control"); page.keyboard.press("KeyK"); page.keyboard.up("Control")
         time.sleep(0.15)
-        page.keyboard.type(url)
+        fast_type(page, url)
         time.sleep(0.05)
         page.keyboard.press("Enter")
         time.sleep(0.05)
@@ -175,7 +180,7 @@ def post_to_substack(md_path, publish=False, cover_path="cover.png"):
 
                 # Bullets -> dot
                 if line.startswith("- "):
-                    page.keyboard.type("• ")
+                    fast_type(page, "• ")
                     line = line[2:].strip()
 
                 # Type text with labeled links
@@ -187,7 +192,7 @@ def post_to_substack(md_path, publish=False, cover_path="cover.png"):
                     url   = m.group(2)
                     print(f"Typing link: label={label}, url={url}")
                     if before:
-                        page.keyboard.type(before)
+                        fast_type(page, before)
 
                     # Your old, working popup flow
                     
@@ -195,10 +200,10 @@ def post_to_substack(md_path, publish=False, cover_path="cover.png"):
                     page.keyboard.press("KeyK")
                     page.keyboard.up(LINK_MOD)
                     time.sleep(0.2)
-                    page.keyboard.type(label)
+                    fast_type(page, label)
                     page.keyboard.press("Tab")
                     time.sleep(0.2)
-                    page.keyboard.type(url)
+                    fast_type(page, url)
                     time.sleep(0.2)
                     page.keyboard.press("Enter")
                     time.sleep(0.2)
@@ -208,7 +213,7 @@ def post_to_substack(md_path, publish=False, cover_path="cover.png"):
 
 
                 if pos < len(line):
-                    page.keyboard.type(line[pos:])
+                    fast_type(page, line[pos:])
 
                 page.keyboard.press("Enter")
         page.keyboard.press("Enter")


### PR DESCRIPTION
### Motivation
- Restore the original timing around Substack link-dialog interactions to avoid UI races while keeping the `fast_type` helper for faster bulk text insertion.

### Description
- Reverted the shortened sleeps in the link flow by increasing `time.sleep` calls in `insert_link` and the link-handling loop (e.g. `0.15` and `0.2` delays) so the dialog and inputs have the previous wait time while retaining `fast_type` usage.

### Testing
- No automated tests were run for this change (not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e38d0619c8331993270944a732f51)