### PR TITLE
Refine repository AGENTS guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# AGENTS.md
+
+## Scope
+This file applies to the entire repository unless a more specific AGENTS.md exists in a subdirectory.
+
+## Repository overview
+- `src/main.py` orchestrates the daily pipeline: download the RIK news video, extract audio, transcribe, summarize, generate cover art, and optionally post to Substack.
+- `src/summarize.py` handles chunked summarization and section ordering using prompt templates in `src/prompts/`.
+- `src/transcribe.py` handles speech-to-text for the downloaded audio.
+- `src/post_to_substack.py` uses Playwright and a saved session to publish to Substack.
+- `summaries/` is the default output root for generated artifacts (override with `SUMMARIES_ROOT`).
+- `cyprus-news-cron` shows the production cron invocation and required environment setup.
+
+## Conventions & design notes
+- Generated daily outputs live under `summaries/YYYY-MM-DD/{media,txt}` and are referenced by helpers in `src/helpers.py`.
+- Prompts are plain text files in `src/prompts/`; when editing prompts, keep formatting consistent and avoid trailing whitespace.
+- Summaries expect canonical section headings (e.g., "Top stories", "Culture") in `summarize.combine_summaries`; update tests if you change the section list.
+- Avoid adding new network calls inside tests; tests are expected to run offline.
+
+## Environment & secrets
+- `SECRETS_ROOT` points to a folder containing `env.sh` and `substack_session.json` (see `cyprus-news-cron`).
+- `SUMMARIES_ROOT` overrides the default summaries output directory (see `src/helpers.py`).
+- OpenAI credentials must be supplied via environment variables when running summarization or image generation.
+
+## Testing
+- Unit tests live in `tests/` and use `unittest`.
+- Run the suite with `python -m unittest` from the repo root.
+
+## PR notes
+- Summaries should be concise and list user-visible changes.
+- Call out changes to prompts or the publishing pipeline explicitly.


### PR DESCRIPTION
### Motivation
- Replace the previous generic guidance with repository-specific notes that map to the actual pipeline and files in this project.
- Make it easier for contributors to understand where daily outputs live, how prompts are organized, and what runtime secrets are required.
- Surface the production cron invocation and overrideable environment variables so maintainers can reproduce the pipeline locally.

### Description
- Add `AGENTS.md` containing a repository overview that references `src/main.py`, `src/summarize.py`, `src/transcribe.py`, `src/post_to_substack.py`, and the `src/prompts/` folder.
- Document output layout and helpers by calling out `summaries/YYYY-MM-DD/{media,txt}` and `src/helpers.py` and note `SUMMARIES_ROOT` as the override.
- Record environment and secrets usage by referencing `SECRETS_ROOT`, `env.sh`, and `substack_session.json`, and show the production cron entry in `cyprus-news-cron`.
- Add testing guidance that points to the existing `tests/` suite and the command to run it (`python -m unittest`).

### Testing
- No automated tests were run for this change.
- The repository already contains unit tests in `tests/` (unchanged) that can be executed with `python -m unittest`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e38e4d9608331a35b26e69e9f6056)