### PR TITLE
Add debug logs to Substack posting flow

### DIFF
--- a/src/summarize.py
+++ b/src/summarize.py
@@ -14,6 +14,7 @@ from dateutil.parser import parse as parse_datetime, ParserError
 from textwrap import dedent
 import time
 import tiktoken
+from timing import timing_step
 
 
 # --- Configuration ---
@@ -291,6 +292,10 @@ def summarize_for_day(day):
 
     # --- Load required files ---
     output_folder = get_text_folder_for_day(day)
+    log_context = {
+        "date": day.isoformat(),
+        "output_folder": output_folder,
+    }
 
     date_heading = f"## 📰 News Summary for {day.strftime('%A, %d %B %Y')}\n\n"
     cyprus_now = datetime.now(ZoneInfo("Asia/Nicosia"))
@@ -305,21 +310,23 @@ def summarize_for_day(day):
     output_file = output_folder / "summary.txt"
     transcript_file = output_folder / "transcript_gr.txt"
 
-    with open(transcript_file, "r", encoding="utf-8") as f:
-        transcript_text = f.read()
-    with open(PROMPT_FILE, "r", encoding="utf-8") as f:
-        prompt_text = f.read().strip().replace("[DATE]", day.strftime('%A, %d %B %Y'))
-    with open(LINK_PROMPT_FILE, "r", encoding="utf-8") as f:
-        link_prompt = f.read().strip()
-    with open(DEDUPLICATION_PROMPT_FILE, "r", encoding="utf-8") as f:
-        deduplication_prompt = f.read().strip()
+    with timing_step("summarize_read_transcript", **log_context, transcript_path=transcript_file):
+        with open(transcript_file, "r", encoding="utf-8") as f:
+            transcript_text = f.read()
+    with timing_step("summarize_load_prompts", **log_context):
+        with open(PROMPT_FILE, "r", encoding="utf-8") as f:
+            prompt_text = f.read().strip().replace("[DATE]", day.strftime('%A, %d %B %Y'))
+        with open(LINK_PROMPT_FILE, "r", encoding="utf-8") as f:
+            link_prompt = f.read().strip()
+        with open(DEDUPLICATION_PROMPT_FILE, "r", encoding="utf-8") as f:
+            deduplication_prompt = f.read().strip()
 
-    with open(FIRST_CHUNK_SYSTEM_PROMPT_FILE, "r", encoding="utf-8") as f:
-        first_chunk_system_prompt = f.read().strip()
-    with open(FOLLOWUP_CHUNK_SYSTEM_PROMPT_FILE, "r", encoding="utf-8") as f:
-        followup_chunk_system_prompt = f.read().strip()
-    with open(HEADLINE_SYSTEM_PROMPT_FILE, "r", encoding="utf-8") as f:
-        headline_system_prompt = f.read().strip()
+        with open(FIRST_CHUNK_SYSTEM_PROMPT_FILE, "r", encoding="utf-8") as f:
+            first_chunk_system_prompt = f.read().strip()
+        with open(FOLLOWUP_CHUNK_SYSTEM_PROMPT_FILE, "r", encoding="utf-8") as f:
+            followup_chunk_system_prompt = f.read().strip()
+        with open(HEADLINE_SYSTEM_PROMPT_FILE, "r", encoding="utf-8") as f:
+            headline_system_prompt = f.read().strip()
         
 
     client = OpenAI()
@@ -332,11 +339,19 @@ def summarize_for_day(day):
             summary = f.read().replace(date_heading + "\n\n", "", 1)
         usage1 = None
     else:
-        summary, usage1 =  generate_chunked_summary(transcript_text, client, prompt_text, first_chunk_system_prompt, followup_chunk_system_prompt, headline_system_prompt)
+        with timing_step("summarize_generate_chunked", **log_context, summary_path=summary_file):
+            summary, usage1 =  generate_chunked_summary(
+                transcript_text,
+                client,
+                prompt_text,
+                first_chunk_system_prompt,
+                followup_chunk_system_prompt,
+                headline_system_prompt,
+            )
 
-        with open(summary_file, "w", encoding="utf-8") as f:
-            f.write(date_heading + "\n\n" + summary)
-        print(f"✅ Summary saved to {summary_file}")
+            with open(summary_file, "w", encoding="utf-8") as f:
+                f.write(date_heading + "\n\n" + summary)
+            print(f"✅ Summary saved to {summary_file}")
 
     start_date = day - timedelta(days=1)
     end_date = day + timedelta(days=1)
@@ -344,14 +359,17 @@ def summarize_for_day(day):
 
     top_stories, main_summary = split_summary(summary)
 
-    cleaned_main_summary, usage2 = cleanup_merged_summary(client, main_summary, deduplication_prompt)
+    with timing_step("summarize_cleanup", **log_context):
+        cleaned_main_summary, usage2 = cleanup_merged_summary(client, main_summary, deduplication_prompt)
 
-    linked_main_summary, usage3 = link_articles_to_summary(client, cleaned_main_summary, filtered_articles, link_prompt)
+    with timing_step("summarize_link_articles", **log_context):
+        linked_main_summary, usage3 = link_articles_to_summary(client, cleaned_main_summary, filtered_articles, link_prompt)
 
     final_output = date_heading + "\n\n" + top_stories + "\n\n" + linked_main_summary
 
-    with open(output_file, "w", encoding="utf-8") as f:
-        f.write(final_output)
+    with timing_step("summarize_write_output", **log_context, summary_path=output_file):
+        with open(output_file, "w", encoding="utf-8") as f:
+            f.write(final_output)
 
     # --- Token usage & cost ---
     total_tokens = 0

--- a/src/timing.py
+++ b/src/timing.py
@@ -1,0 +1,47 @@
+import json
+import time
+from contextlib import contextmanager
+from datetime import datetime
+from pathlib import Path
+
+from helpers import SUMMARIES_ROOT
+
+
+def _coerce_json_value(value):
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, (list, tuple)):
+        return [_coerce_json_value(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _coerce_json_value(val) for key, val in value.items()}
+    return value
+
+
+def get_timings_log_path() -> Path:
+    return SUMMARIES_ROOT / "timings.log"
+
+
+def log_timing(label: str, start_time: float, end_time: float, **context) -> None:
+    duration = end_time - start_time
+    payload = {
+        "timestamp": datetime.utcnow().isoformat(timespec="seconds") + "Z",
+        "label": label,
+        "duration_s": round(duration, 6),
+    }
+    if context:
+        payload.update(_coerce_json_value(context))
+
+    log_path = get_timings_log_path()
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open("a", encoding="utf-8") as log_file:
+        log_file.write(json.dumps(payload, ensure_ascii=False) + "\n")
+
+
+@contextmanager
+def timing_step(label: str, **context):
+    start = time.perf_counter()
+    try:
+        yield
+    finally:
+        end = time.perf_counter()
+        log_timing(label, start, end, **context)

--- a/src/transcribe.py
+++ b/src/transcribe.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from datetime import date
 from helpers import get_media_folder_for_day, get_text_folder_for_day
 from openai import OpenAI
+from timing import timing_step
 
 MAX_RETRIES = 3
 MIN_EXPECTED_CHARS = 1000  # Adjust depending on your clip length/content
@@ -45,31 +46,41 @@ def transcribe_for_day(day : date):
     output_folder = get_text_folder_for_day(day)
     txt_output = output_folder / "transcript_gr.txt"
     json_output = output_folder / "transcript_gr.json"
+    log_context = {
+        "date": day.isoformat(),
+        "media_folder": mp3_folder,
+        "transcript_path": txt_output,
+        "transcript_json_path": json_output,
+    }
     i = 0
-    while True:
-        filename = mp3_folder / f"split_audio{i:03d}.mp3"
-        if not os.path.exists(filename):
-            break
-        print_helper(f"Transcribing {filename}...")
-        with open(filename, "rb") as audio_file:
-            result = transcribe_with_retry(
-                client,
-                audio_file
-            )
-            combined_text.append(result.text)
-            combined_json.append(result.model_dump())  # Convert to dict for JSON
-        i += 1
+    with timing_step("transcription_loop", **log_context):
+        while True:
+            filename = mp3_folder / f"split_audio{i:03d}.mp3"
+            if not os.path.exists(filename):
+                break
+            print_helper(f"Transcribing {filename}...")
+            with timing_step("transcription_chunk", **log_context, chunk_index=i, chunk_path=filename):
+                with open(filename, "rb") as audio_file:
+                    result = transcribe_with_retry(
+                        client,
+                        audio_file
+                    )
+                    combined_text.append(result.text)
+                    combined_json.append(result.model_dump())  # Convert to dict for JSON
+            i += 1
 
     if i == 0:
         raise SystemExit(f"No input files found in directory: {mp3_folder}")
 
     # --- Save plain text ---
-    with open(txt_output, "w", encoding="utf-8") as f:
-        f.write("\n\n".join(combined_text))
+    with timing_step("transcription_write_text", **log_context):
+        with open(txt_output, "w", encoding="utf-8") as f:
+            f.write("\n\n".join(combined_text))
 
     # --- Save full JSON ---
-    with open(json_output, "w", encoding="utf-8") as f:
-        json.dump(combined_json, f, ensure_ascii=False, indent=2)
+    with timing_step("transcription_write_json", **log_context):
+        with open(json_output, "w", encoding="utf-8") as f:
+            json.dump(combined_json, f, ensure_ascii=False, indent=2)
 
     print_helper(f"✅ Saved transcript to {txt_output}")
     print_helper(f"📦 Saved full JSON to {json_output}")


### PR DESCRIPTION
### Motivation
- Posting sometimes created multiple drafts and failed to publish, so more runtime diagnostics were added around the Playwright Substack flow to capture cause and context. 
- Existing timing instrumentation was kept to correlate UI behavior with pipeline steps for easier root-cause analysis. 

### Description
- Added `log_info` and sprinkled explicit `SUBSTACK:` debug prints throughout `src/post_to_substack.py` to record session usage, navigation, editor load, title/body entry, subscribe-button insertion, and publish/draft outcomes. 
- Capture failure context via screenshots (`substack_title_missing.png`, `substack_publish_failed.png`) and log exception messages when critical selectors or publish actions fail. 
- Continued/expanded runtime observability by using `timing_step` wrappers and contextual `log_context` in `src/main.py`, `src/summarize.py`, and `src/transcribe.py`, and added the helper `src/timing.py` to persist JSONL timing entries. 

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e48f145d88331a1a0539f94fa7e0b)