### PR TITLE
Fix date handling in summary reference logic

### DIFF
--- a/src/summarize.py
+++ b/src/summarize.py
@@ -6,7 +6,7 @@ import re
 import sys
 import argparse
 import json
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 from zoneinfo import ZoneInfo
 from helpers import get_text_folder_for_day
 from openai import OpenAI
@@ -307,10 +307,11 @@ def summarize_for_day(day):
 
     date_heading = f"## 📰 News Summary for {day.strftime('%A, %d %B %Y')}\n\n"
     cyprus_now = datetime.now(ZoneInfo("Asia/Nicosia"))
+    day_date = day.date() if isinstance(day, datetime) else day
     summary_reference = "yesterday's"
-    if cyprus_now.date() == day.date():
+    if cyprus_now.date() == day_date:
         summary_reference = "this evening's"
-    elif cyprus_now.date() == (day + timedelta(days=1)).date() and cyprus_now.hour < 2:
+    elif cyprus_now.date() == (day_date + timedelta(days=1)) and cyprus_now.hour < 2:
         summary_reference = "this evening's"
     date_heading += f"This is a summary of {summary_reference} [8pm RIK news broadcast](https://tv.rik.cy/show/eideseis-ton-8/). Where available, links to related English-language articles from the Cyprus Mail and In-Cyprus are provided for further reading. Please note that this summary was generated with the assistance of AI and may contain inaccuracies."
 


### PR DESCRIPTION
### Motivation
- Fix a crash in `summarize_for_day` when `day` is a `datetime.date` (the code previously called `day.date()` and raised `AttributeError`).

### Description
- Import `date` from `datetime` and normalize the incoming `day` value with `day_date = day.date() if isinstance(day, datetime) else day` so comparisons always use a `date` object.
- Replace comparisons that used `day.date()` with `day_date` and update the next-day check to use `day_date + timedelta(days=1)`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69777c23a8e08331ad6d86d70c474323)