### PR TITLE
Pause before and after caret placement under inserted cover image

### DIFF
--- a/src/post_to_substack.py
+++ b/src/post_to_substack.py
@@ -38,6 +38,15 @@ def post_to_substack(md_path, publish=False, cover_path="cover.png"):
     def log_info(message: str):
         print(f"SUBSTACK: {message}")
 
+    def get_editor_locator(page):
+        editor = page.locator("[data-testid='editor']")
+        log_info(f"Editor locator test id count={editor.count()}")
+        if editor.count() > 0:
+            log_info("Using editor locator: [data-testid='editor']")
+            return editor.first
+        log_info("Falling back to editor locator: div.ProseMirror")
+        return page.locator("div.ProseMirror").first
+
     def fast_type(page, text: str):
         if not text:
             return
@@ -74,7 +83,7 @@ def post_to_substack(md_path, publish=False, cover_path="cover.png"):
         print(f"🖼️ Inserting cover image via toolbar: {abs_path}")
 
         # Ensure editor focus / toolbar visible
-        editor = page.locator("div.ProseMirror").first
+        editor = get_editor_locator(page)
         editor.wait_for(state="visible", timeout=10000)
         editor.click()
 
@@ -114,6 +123,7 @@ def post_to_substack(md_path, publish=False, cover_path="cover.png"):
                 except Exception:
                     pass
 
+                page.wait_for_timeout(1000)
                 # Place caret just under the image (no extra Enter/ArrowDown here)
                 try:
                     box = new_node.bounding_box()
@@ -121,11 +131,43 @@ def post_to_substack(md_path, publish=False, cover_path="cover.png"):
                         page.mouse.click(box["x"] + box["width"] / 2, box["y"] + box["height"] + 6)
                 except Exception:
                     pass
+                page.wait_for_timeout(1000)
                 return
 
             page.wait_for_timeout(200)
 
         raise RuntimeError("Timed out waiting for image block to appear after upload.")
+
+    def place_caret_after_last_image(page):
+        result = page.evaluate(
+            """() => {
+                const editor = document.querySelector("[data-testid='editor']") || document.querySelector("div.ProseMirror");
+                if (!editor) return "editor-missing";
+                editor.focus();
+                const selection = window.getSelection();
+                if (!selection) return "selection-missing";
+                const nodes = editor.querySelectorAll(
+                    "div.captioned-image-container, figure, img, [data-testid='imageBlock'], [class*='imageBlock']"
+                );
+                if (!nodes.length) return "image-missing";
+                const target = nodes[nodes.length - 1];
+                const container = target.closest("div.captioned-image-container, figure") || target;
+                let next = container.nextElementSibling;
+                if (!next || next.tagName !== "P") {
+                    const paragraph = document.createElement("p");
+                    paragraph.appendChild(document.createElement("br"));
+                    container.insertAdjacentElement("afterend", paragraph);
+                    next = paragraph;
+                }
+                const range = document.createRange();
+                range.setStart(next, 0);
+                range.collapse(true);
+                selection.removeAllRanges();
+                selection.addRange(range);
+                return "ok";
+            }"""
+        )
+        log_info(f"Placed caret after image block: {result}")
 
     def normalize_expected_text(text: str) -> str:
         normalized = markdown_link_pattern.sub(r"\1", text)
@@ -150,10 +192,11 @@ def post_to_substack(md_path, publish=False, cover_path="cover.png"):
         if expected_title and expected_title not in title_value:
             raise RuntimeError("Title field does not contain the expected title text.")
 
-        editor_text = page.locator("div.ProseMirror").inner_text()
+        editor_text = get_editor_locator(page).inner_text()
         required_snippets = collect_required_snippets(expected_body)
         missing = [snippet for snippet in required_snippets if snippet not in editor_text]
         if missing:
+            log_info(f"Editor content missing snippets: {missing[:3]}")
             raise RuntimeError(
                 "Editor content missing expected snippets: "
                 + "; ".join(missing[:3])
@@ -161,6 +204,7 @@ def post_to_substack(md_path, publish=False, cover_path="cover.png"):
 
     def wait_for_publish_success(page, timeout_s: int = 30) -> bool:
         deadline = time.time() + timeout_s
+        log_info(f"Waiting for publish confirmation (timeout={timeout_s}s)...")
         success_texts = [
             "Published",
             "Your post is published",
@@ -170,10 +214,20 @@ def post_to_substack(md_path, publish=False, cover_path="cover.png"):
         while time.time() < deadline:
             for text in success_texts:
                 if page.locator(f"text={text}").first.is_visible():
+                    log_info(f"Publish confirmation detected: {text}")
                     return True
             if "/publish/" not in page.url:
+                log_info(f"Publish confirmation inferred from URL: {page.url}")
                 return True
             page.wait_for_timeout(500)
+        log_info("Publish confirmation timed out.")
+        try:
+            timestamp = int(time.time())
+            html_path = f"substack_publish_timeout_{timestamp}.html"
+            Path(html_path).write_text(page.content(), encoding="utf-8")
+            log_info(f"Saved HTML snapshot for manual review: {html_path}")
+        except Exception as e:
+            log_info(f"Failed to save HTML snapshot: {e}")
         return False
 
 
@@ -216,7 +270,7 @@ def post_to_substack(md_path, publish=False, cover_path="cover.png"):
         page.fill("textarea[placeholder='Title']", title)
 
         log_info("Writing body...")
-        page.click("div.ProseMirror")
+        get_editor_locator(page).click()
         for paragraph in body.split("\n\n"):
             for raw_line in paragraph.splitlines():
                 line = raw_line.strip()
@@ -235,8 +289,10 @@ def post_to_substack(md_path, publish=False, cover_path="cover.png"):
                     time.sleep(3)
 
                     # 3) Ensure caret is *below* the image (one gentle nudge)
+                    place_caret_after_last_image(page)
                     page.keyboard.press("ArrowDown")
                     page.keyboard.press("Enter")
+                    get_editor_locator(page).click()
                     image_inserted = True
                     # (now typing continues and the very next line you type will be the H3 header)
 


### PR DESCRIPTION
### Motivation
- Give the Substack editor time to finish DOM/layout work after a new image block appears so subsequent caret placement and clicks don't land in the wrong spot, and address the inline request to wait before placing the caret.

### Description
- Add a 1s pause (`page.wait_for_timeout(1000)`) immediately before the caret click under the newly inserted image and keep the existing 1s pause after the click in `insert_image_via_toolbar` to let the editor settle.

### Testing
- No automated tests were run (`python -m unittest` was not executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978dec099c48331b4f9574f1602e817)