### PR TITLE
Fix Russian summary link prefixes for relative source URLs

### DIFF
--- a/config/languages.json
+++ b/config/languages.json
@@ -34,8 +34,8 @@
     "enabled": true,
     "summary_source": "translate_from:en",
     "article_sources": [
-      {"name": "EvropaKipr", "tag": "ЕК", "file": "data/evropakipr_novosti_articles.json"},
-      {"name": "Cyprus Butterfly", "tag": "CB", "file": "data/cyprusbutterfly_articles.json"}
+      {"name": "EvropaKipr", "tag": "ЕК", "file": "data/evropakipr_novosti_articles.json", "base_url": "https://evropakipr.com"},
+      {"name": "Cyprus Butterfly", "tag": "CB", "file": "data/cyprusbutterfly_articles.json", "base_url": "https://cyprusbutterfly.com.cy"}
     ],
     "summary_filename": "summary_ru.txt",
     "summary_without_links_filename": "summary_without_links_ru.txt",

--- a/src/summarize.py
+++ b/src/summarize.py
@@ -6,6 +6,7 @@ import re
 import sys
 import argparse
 import json
+from urllib.parse import urljoin
 from datetime import date, datetime, timedelta
 from zoneinfo import ZoneInfo
 from helpers import get_text_folder_for_day
@@ -205,6 +206,7 @@ def load_articles(start_date, end_date, article_sources=None):
         article_sources = get_article_sources("en")
     results = []
     for source in article_sources:
+        base_url = source.get("base_url")
         if not os.path.exists(source["file"]):
             continue
         with open(source["file"], "r", encoding="utf-8") as f:
@@ -223,10 +225,13 @@ def load_articles(start_date, end_date, article_sources=None):
             except (ParserError, ValueError):
                 continue
             if start_date <= dt.date() <= end_date:
+                article_url = a.get("url")
+                if base_url and article_url:
+                    article_url = urljoin(base_url, article_url)
                 results.append({
                     "t": a.get("title"),
                     "a": a.get("abstract"),
-                    "u": a.get("url"),
+                    "u": article_url,
                     "tag": source["tag"]
                 })
     return results

--- a/tests/test_summarize.py
+++ b/tests/test_summarize.py
@@ -44,6 +44,34 @@ class SummarizeTestCase(unittest.TestCase):
         # Duplicate tag should only appear once
         self.assertEqual(examples.count("(ΦΝ)"), 1)
 
+
+    def test_load_articles_applies_base_url_to_relative_links(self):
+        from tempfile import TemporaryDirectory
+        import json
+        from datetime import date
+
+        with TemporaryDirectory() as tmp:
+            data_file = Path(tmp) / "articles.json"
+            data_file.write_text(json.dumps([
+                {
+                    "title": "Sample",
+                    "abstract": "Desc",
+                    "datetime": "2026-02-17T00:00:00",
+                    "url": "/novosti/example"
+                }
+            ]), encoding="utf-8")
+
+            sources = [{
+                "name": "EvropaKipr",
+                "tag": "ЕК",
+                "file": str(data_file),
+                "base_url": "https://evropakipr.com"
+            }]
+            articles = summarize.load_articles(date(2026, 2, 17), date(2026, 2, 17), sources)
+
+            self.assertEqual(len(articles), 1)
+            self.assertEqual(articles[0]["u"], "https://evropakipr.com/novosti/example")
+
     def test_build_tag_examples_english(self):
         sources = [
             {"name": "Cyprus Mail", "tag": "CM", "file": "data/cyprus_articles.json"},


### PR DESCRIPTION
### Motivation
- Russian summaries were producing path-only links like `/(novosti/...)` because article JSONs store relative URLs and link injection used them unchanged.
- The intent is to ensure injected markdown links for RU sources are absolute so Substack posts and previews point to the correct site.
- Existing stored JSON files do not need to be deleted because the normalization happens at load/link time.

### Description
- Resolve relative article URLs by adding optional `base_url` support in `load_articles` and expanding `url` with `urljoin` before linking.
- Add `base_url` entries for Russian sources (`EvropaKipr`, `Cyprus Butterfly`) in `config/languages.json` so their `(ЕК)` / `(CB)` links become absolute.
- Add a unit test `test_load_articles_applies_base_url_to_relative_links` to `tests/test_summarize.py` to verify relative URLs are expanded when `base_url` is provided.

### Testing
- Ran the summarize-focused tests with `python -m unittest discover -s tests -p 'test_summarize.py' -v` and all tests passed.
- Ran the full test discovery `python -m unittest discover -s tests -p 'test_*.py'` and observed one pre-existing unrelated failure in `test_philenews_loader.PhilenewsLoaderTestCase.test_parse_relative_time_returns_none` (failure not caused by these changes).
- The new unit test covering base-URL expansion was executed and succeeded as part of the summarize tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995767bfac48331952a7384b635999d)